### PR TITLE
5 feature create in memory data storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build:
 	go build -o $(OBJDIR)	./...
 
 test:
+	go clean -testcache
 	go test -race ./...
 
 run: build

--- a/pkg/customerrors/client.go
+++ b/pkg/customerrors/client.go
@@ -1,4 +1,4 @@
-package payloads
+package customerrors
 
 import (
 	"fmt"

--- a/pkg/customerrors/datastorage.go
+++ b/pkg/customerrors/datastorage.go
@@ -1,0 +1,17 @@
+package customerrors
+
+import "fmt"
+
+// DataStorageNameNotFound is an `error` that is associated with a failed key
+// access to a `DataStorage` - there is no stored data associated with the given
+// `Name`.
+type DataStorageNameNotFound struct {
+	Name string
+}
+
+func (e DataStorageNameNotFound) Error() string {
+	return fmt.Sprintf(
+		"attempted to access data associated with name: %s - not found",
+		e.Name,
+	)
+}

--- a/pkg/datastorage/datastorage.go
+++ b/pkg/datastorage/datastorage.go
@@ -8,7 +8,7 @@ type DataStorage interface {
 	//
 	// Returns the data in byte forms if found, error elsewise.
 	//
-	// This method is concurrently safe - multiple reads to the same data is
+	// This method is thread safe - multiple reads to the same data is
 	// allowed but writers will be blocked until their turn.
 	RetrieveData(name string) ([]byte, error)
 
@@ -18,7 +18,7 @@ type DataStorage interface {
 	// This method will overwrite existing data if an already existing `name` is
 	// given - returns an error if write fails.
 	//
-	// Callers may assume this method is concurrently safe.
+	// Callers may assume this method is thread safe.
 	StoreData(name string, data []byte) error
 
 	// DeleteData allows uers to delete data associated with a given `name`.
@@ -26,6 +26,6 @@ type DataStorage interface {
 	// This method returns an error if there is no data associated with `name`,
 	// or if the deletion fails.
 	//
-	// Callers may assume this method is concurrently safe.
+	// Callers may assume this method is thread safe.
 	DeleteData(name string) error
 }

--- a/pkg/datastorage/datastorage.go
+++ b/pkg/datastorage/datastorage.go
@@ -1,0 +1,30 @@
+package datastorage
+
+// DataStorage is an interface to be satisified by any storage implementation,
+// regardless of whether it is in memory, drive, etc.
+type DataStorage interface {
+	// RetrieveData allows user access to the DataStorage implementation,
+	// retrieving data associated with the given `name`.
+	//
+	// Returns the data in byte forms if found, error elsewise.
+	//
+	// This method is concurrently safe - multiple reads to the same data is
+	// allowed but writers will be blocked until their turn.
+	RetrieveData(name string) ([]byte, error)
+
+	// StoreData allows users to store given `data` (bytes) with an associated
+	// `name`.
+	//
+	// This method will overwrite existing data if an already existing `name` is
+	// given - returns an error if write fails.
+	//
+	// Callers may assume this method is concurrently safe.
+	StoreData(name string, data []byte) error
+
+	// DeleteData allows uers to delete data associated with a given `name`.
+	//
+	// This method returns an error if there is no data associated with `name`,
+	// or if the deletion fails.
+	//
+	// Callers may assume this method is concurrently safe.
+}

--- a/pkg/datastorage/datastorage.go
+++ b/pkg/datastorage/datastorage.go
@@ -3,6 +3,9 @@ package datastorage
 // DataStorage is an interface to be satisified by any storage implementation,
 // regardless of whether it is in memory, drive, etc.
 type DataStorage interface {
+	// Initialize creates and returns a pointer to a clean `DataStorage`
+	Initialize() DataStorage
+
 	// RetrieveData allows user access to the DataStorage implementation,
 	// retrieving data associated with the given `name`.
 	//

--- a/pkg/datastorage/datastorage.go
+++ b/pkg/datastorage/datastorage.go
@@ -27,4 +27,5 @@ type DataStorage interface {
 	// or if the deletion fails.
 	//
 	// Callers may assume this method is concurrently safe.
+	DeleteData(name string) error
 }

--- a/pkg/datastorage/datastorage.go
+++ b/pkg/datastorage/datastorage.go
@@ -3,9 +3,6 @@ package datastorage
 // DataStorage is an interface to be satisified by any storage implementation,
 // regardless of whether it is in memory, drive, etc.
 type DataStorage interface {
-	// Initialize creates and returns a pointer to a clean `DataStorage`
-	Initialize() DataStorage
-
 	// RetrieveData allows user access to the DataStorage implementation,
 	// retrieving data associated with the given `name`.
 	//

--- a/pkg/datastorage/memstorage.go
+++ b/pkg/datastorage/memstorage.go
@@ -31,11 +31,10 @@ func (ms MemStorage) Initialize() *MemStorage {
 //
 // This method is thread safe.
 func (ms *MemStorage) RetrieveData(name string) ([]byte, error) {
-	// Acquire a read lock
+	// Only block writers
 	ms.rwMu.RLock()
 	defer ms.rwMu.RUnlock()
 
-	// Check if data exists associated with the given name
 	data, found := ms.data[name]
 	if !found {
 		return []byte{}, customerrors.DataStorageNameNotFound{
@@ -43,7 +42,6 @@ func (ms *MemStorage) RetrieveData(name string) ([]byte, error) {
 		}
 	}
 
-	// Return data with no error elsewise
 	return data, nil
 }
 
@@ -56,15 +54,11 @@ func (ms *MemStorage) RetrieveData(name string) ([]byte, error) {
 //
 // This method is thread safe.
 func (ms *MemStorage) StoreData(name string, data []byte) error {
-	// Acquire a complete mutual exclusion lock
 	ms.rwMu.Lock()
 	defer ms.rwMu.Unlock()
 
-	// Write the data and map to the assigned name
 	ms.data[name] = data
 
-	// TODO: add error handling for any future features that may require it,
-	// e.g. memory capacity, etc.
 	return nil
 }
 
@@ -74,11 +68,9 @@ func (ms *MemStorage) StoreData(name string, data []byte) error {
 //
 // This method is thread safe.
 func (ms *MemStorage) DeleteData(name string) error {
-	// Acquire a complete mutual exclusion lock
 	ms.rwMu.Lock()
 	defer ms.rwMu.Unlock()
 
-	// Check if data exists associated with the given name
 	_, found := ms.data[name]
 	if !found {
 		return customerrors.DataStorageNameNotFound{
@@ -86,7 +78,6 @@ func (ms *MemStorage) DeleteData(name string) error {
 		}
 	}
 
-	// Delete the data and return no error
 	delete(ms.data, name)
 	return nil
 }

--- a/pkg/datastorage/memstorage.go
+++ b/pkg/datastorage/memstorage.go
@@ -13,7 +13,7 @@ import (
 // `string` keys.
 type MemStorage struct {
 	data map[string][]byte
-	rwMu *sync.RWMutex
+	rwMu sync.RWMutex
 }
 
 // InitializeMemStorage initializes and returns a pointer to a clean

--- a/pkg/datastorage/memstorage.go
+++ b/pkg/datastorage/memstorage.go
@@ -16,6 +16,14 @@ type MemStorage struct {
 	rwMu *sync.RWMutex
 }
 
+// InitializeMemStorage initializes and returns a pointer to a clean
+// `MemStorage`.
+func (ms MemStorage) Initialize() DataStorage {
+	return &MemStorage{
+		data: make(map[string][]byte),
+	}
+}
+
 // RetrieveData checks the `MemStorage` for data associated with a given `name`.
 //
 // If the `name` is found, returns the data (`[]byte`), elsewise returns error.

--- a/pkg/datastorage/memstorage.go
+++ b/pkg/datastorage/memstorage.go
@@ -1,0 +1,83 @@
+package datastorage
+
+import (
+	"sync"
+
+	"github.com/dvo-dev/go-get-started/pkg/customerrors"
+)
+
+// MemStorage is an in-memory storage solution that implements the `DataStorage`
+// interface.
+//
+// MemStorage stores data in the form of `[]byte` in map, with user defined
+// `string` keys.
+type MemStorage struct {
+	data map[string][]byte
+	rwMu *sync.RWMutex
+}
+
+// RetrieveData checks the `MemStorage` for data associated with a given `name`.
+//
+// If the `name` is found, returns the data (`[]byte`), elsewise returns error.
+//
+// This method is thread safe.
+func (ms *MemStorage) RetrieveData(name string) ([]byte, error) {
+	// Acquire a read lock
+	ms.rwMu.RLock()
+	defer ms.rwMu.RUnlock()
+
+	// Check if data exists associated with the given name
+	data, found := ms.data[name]
+	if !found {
+		return []byte{}, customerrors.DataStorageNameNotFound{
+			Name: name,
+		}
+	}
+
+	// Return data with no error elsewise
+	return data, nil
+}
+
+// StoreData writes data `[]byte` to the `MemStorage`, mapping it to the given
+// `name`.
+//
+// If the `name` already exists, it will overwrite the previous data values.
+//
+// Returns an error if writing fails.
+//
+// This method is thread safe.
+func (ms *MemStorage) StoreData(name string, data []byte) error {
+	// Acquire a complete mutual exclusion lock
+	ms.rwMu.Lock()
+	defer ms.rwMu.Unlock()
+
+	// Write the data and map to the assigned name
+	ms.data[name] = data
+
+	// TODO: add error handling for any future features that may require it,
+	// e.g. memory capacity, etc.
+	return nil
+}
+
+// DeleteData removes data in the `MemStorage` associated with the given `name`.
+//
+// If the `name` does not exist, an error will be returned.
+//
+// This method is thread safe.
+func (ms *MemStorage) DeleteData(name string) error {
+	// Acquire a complete mutual exclusion lock
+	ms.rwMu.Lock()
+	defer ms.rwMu.Unlock()
+
+	// Check if data exists associated with the given name
+	_, found := ms.data[name]
+	if !found {
+		return customerrors.DataStorageNameNotFound{
+			Name: name,
+		}
+	}
+
+	// Delete the data and return no error
+	delete(ms.data, name)
+	return nil
+}

--- a/pkg/datastorage/memstorage.go
+++ b/pkg/datastorage/memstorage.go
@@ -13,14 +13,15 @@ import (
 // `string` keys.
 type MemStorage struct {
 	data map[string][]byte
-	rwMu sync.RWMutex
+	rwMu *sync.RWMutex
 }
 
 // InitializeMemStorage initializes and returns a pointer to a clean
 // `MemStorage`.
-func (ms MemStorage) Initialize() DataStorage {
+func (ms MemStorage) Initialize() *MemStorage {
 	return &MemStorage{
 		data: make(map[string][]byte),
+		rwMu: &sync.RWMutex{},
 	}
 }
 

--- a/pkg/datastorage/memstorage_test.go
+++ b/pkg/datastorage/memstorage_test.go
@@ -1,0 +1,157 @@
+package datastorage
+
+import "testing"
+
+func TestMemStorage_ImplementsDataStorage(t *testing.T) {
+	var _ DataStorage = &MemStorage{}
+}
+
+func TestMemStorage_Initialize(t *testing.T) {
+	mem := MemStorage{}.Initialize()
+	if mem == nil {
+		t.Error("returned a nil ptr")
+	}
+
+	if mem.data == nil || len(mem.data) != 0 {
+		t.Error("failed to initialize data map")
+	}
+
+	if mem.rwMu == nil {
+		t.Error("failed to initialize rwMutex")
+	}
+}
+
+func TestMemStorage_RetrieveData(t *testing.T) {
+	mem := MemStorage{}.Initialize()
+	testData := []byte("test data")
+	mem.data["test"] = testData
+
+	t.Run("existing data", func(t *testing.T) {
+		data, err := mem.RetrieveData("test")
+		if err != nil {
+			t.Fatalf("received unexpected error: %v", err)
+		}
+
+		if string(testData) != string(data) {
+			t.Errorf(
+				"expected data: %s but got: %s",
+				testData, data,
+			)
+		}
+	})
+
+	t.Run("nonexistent key", func(t *testing.T) {
+		_, err := mem.RetrieveData("foo")
+		if err == nil {
+			t.Error("expected error but got none")
+		}
+	})
+}
+
+func TestMemStorage_StoreData(t *testing.T) {
+	mem := MemStorage{}.Initialize()
+	dataName := "test"
+	testData := []byte("test data")
+
+	t.Run("first write", func(t *testing.T) {
+		err := mem.StoreData(dataName, testData)
+		if err != nil {
+			t.Fatalf("received unexpected error: %v", err)
+		}
+
+		if len(mem.data) != 1 {
+			t.Errorf(
+				"expected MemStorage data capacity of: %d, but got: %d",
+				1, len(mem.data),
+			)
+		}
+
+		data := mem.data[dataName]
+		if string(testData) != string(data) {
+			t.Errorf(
+				"expected data: %s but got: %s",
+				testData, data,
+			)
+		}
+	})
+
+	t.Run("overwrite", func(t *testing.T) {
+		testData = []byte("foobar")
+		err := mem.StoreData(dataName, testData)
+		if err != nil {
+			t.Fatalf("received unexpected error: %v", err)
+		}
+
+		if len(mem.data) != 1 {
+			t.Errorf(
+				"expected MemStorage data capacity of: %d, but got: %d",
+				1, len(mem.data),
+			)
+		}
+
+		data := mem.data[dataName]
+		if string(testData) != string(data) {
+			t.Errorf(
+				"expected data: %s but got: %s",
+				testData, data,
+			)
+		}
+	})
+
+	t.Run("new data", func(t *testing.T) {
+		dataName2 := "test2"
+		testData2 := []byte("qwerty")
+		err := mem.StoreData(dataName2, testData2)
+		if err != nil {
+			t.Fatalf("received unexpected error: %v", err)
+		}
+
+		if len(mem.data) != 2 {
+			t.Errorf(
+				"expected MemStorage data capacity of: %d, but got: %d",
+				2, len(mem.data),
+			)
+		}
+
+		data := mem.data[dataName2]
+		if string(testData2) != string(data) {
+			t.Errorf(
+				"expected data: %s but got: %s",
+				testData2, data,
+			)
+		}
+	})
+}
+
+func TestMemStorage_DeleteData(t *testing.T) {
+	mem := MemStorage{}.Initialize()
+	dataName := "test"
+	testData := []byte("test data")
+
+	err := mem.StoreData(dataName, testData)
+	if err != nil {
+		t.Fatalf("received unexpected error: %v", err)
+	}
+
+	t.Run("delete existing data", func(t *testing.T) {
+		err = mem.DeleteData(dataName)
+		if err != nil {
+			t.Fatalf("received unexpected error: %v", err)
+		}
+
+		if len(mem.data) != 0 {
+			t.Error("MemStorage data should be empty")
+		}
+	})
+
+	t.Run("delete nonexistent data", func(t *testing.T) {
+		err = mem.DeleteData(dataName)
+		if err == nil {
+			t.Error("expected error but got none")
+		}
+
+		if len(mem.data) != 0 {
+			t.Error("MemStorage data should be empty")
+		}
+	})
+}

--- a/pkg/handlers/common.go
+++ b/pkg/handlers/common.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-
-	"github.com/dvo-dev/go-get-started/pkg/payloads"
 )
 
 // RecoveryWrapper is a function wrapper for the actual intended route handling
@@ -56,7 +54,7 @@ func HandleHealth() http.HandlerFunc {
 			})
 
 		default:
-			cErr := payloads.ClientErrorBadMethod{
+			cErr := errors.ClientErrorBadMethod{
 				RequestMethod: r.Method,
 			}
 			w.WriteHeader(cErr.StatusCode())

--- a/pkg/handlers/common.go
+++ b/pkg/handlers/common.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+
+	"github.com/dvo-dev/go-get-started/pkg/customerrors"
 )
 
 // RecoveryWrapper is a function wrapper for the actual intended route handling
@@ -54,7 +56,7 @@ func HandleHealth() http.HandlerFunc {
 			})
 
 		default:
-			cErr := errors.ClientErrorBadMethod{
+			cErr := customerrors.ClientErrorBadMethod{
 				RequestMethod: r.Method,
 			}
 			w.WriteHeader(cErr.StatusCode())


### PR DESCRIPTION
<!--Note these comments do not need to be deleted, and will not show up in the final PR-->

# Summary

### Related Issues
<!--Required-->

- Completes #5

### Contributors
<!--Required-->
- @dvo-dev: implementer

### Affected Modules
<!--Required-->

- `pkg/customerrors` (rename)
- `pkg/datastorage` (new)
- `pkg/handlers` (import update)

### Description
<!--Required-->
Creates the `DataStorage` `interface` as requested in the issue. Also implements an in-memory data storage solution that satisfies `DataStorage`, the `MemStorage`.

`MemStorage` stores data in the form of `[]byte` in memory, and maps the data to user given names (`string`). `MemStorage` is essentially a wrapper for the actual data storage:

```go
data map[string][]byte
```

And provides the ability to read data `MemStorage.RetrieveData`,  write data `MemStorage.StoreData`, and finally delete data `MemStorage.DeleteData`. These operations are thread safe, and are protected by a `sync.RwMutex` contained in `MemStorage`. `RetrieveData` will block writers until their turn (but not concurrent reads), while the other two methods will block both writers + readers.

For initializing a new `MemStorage`, users should use the `Initialize` method, i.e.

```go
mem := MemStorage{}.Initialize()
```

This ensures the data map and mutex is properly initialized and clean, otherwise there may be reference errors, or stale data.

This pull also creates a custom error, `DataStorageNameNotFound` which will be returned when a user attempts to access data with a key that is not registered by any `DataStorage` implementer. As collateral, the previous `payloads` package was updated to the more fitting name of `customerrors`.

# Testing (Unit/Integration/Performance)
<!--Optional if no tests altered/added-->
Checks that `MemStorage` always satisfies the current iteration of `DataStorage`

Basic unit test coverage is added to cover `DataStorage` methods.

A concurrency test is also created, which should fail race condition checks if improper thread safety is utilized for the 3 access methods (`make test` uses the `-race` flag).

# Points of Attention
<!--Optional, use as often as possible-->
- A memory limit should definitely be implemented in the future
- Look to improve concurrent performance by separating mutex calls to individual name:data mappings
