### PR TITLE
10 feature create client request convenience helpers

### DIFF
--- a/pkg/handlers/datastorage.go
+++ b/pkg/handlers/datastorage.go
@@ -86,7 +86,7 @@ func (h *DataStorageHandler) retrieveData(w http.ResponseWriter, r *http.Request
 			"DataStorageHandler - successfully retrieved data with key: '%s'",
 			dataKey,
 		)
-		w.WriteHeader(http.StatusFound)
+		w.WriteHeader(http.StatusOK)
 
 		// Attempt to write response message
 		if rErr := responses.WriteJSON(w,

--- a/pkg/handlers/datastorage_test.go
+++ b/pkg/handlers/datastorage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dvo-dev/go-get-started/pkg/customerrors"
 	"github.com/dvo-dev/go-get-started/pkg/datastorage"
 	"github.com/dvo-dev/go-get-started/pkg/responses"
+	"github.com/dvo-dev/go-get-started/pkg/utils/requests"
 )
 
 // TODO: all these tests need to be rewritten once test helpers are in
@@ -192,7 +193,7 @@ func TestDataStorage_RetrieveData(t *testing.T) {
 	)
 	testServer := httptest.NewServer(dsh.HandleClientRequest())
 	testURL := testServer.URL + "/datastorage"
-	testClient := http.DefaultTransport
+	testClient := http.DefaultClient
 
 	testName := "testname"
 	testData := []byte("test data")
@@ -205,24 +206,12 @@ func TestDataStorage_RetrieveData(t *testing.T) {
 	}
 
 	// Make GET request
-	path := fmt.Sprintf("%s?name=%s", testURL, testName)
-	req, err := http.NewRequest(http.MethodGet, path, nil)
-	if err != nil {
-		t.Fatalf(
-			"unexpected error occurred: %v",
-			err,
-		)
-	}
-	resp, err := testClient.RoundTrip(req)
-	if err != nil {
-		t.Fatalf(
-			"unexpected error occurred: %v",
-			err,
-		)
-	}
+	params := make(map[string]string)
+	params["name"] = testName
+	resp, err := requests.GetRequest(testURL, &params, testClient)
 
 	// Check status code
-	if resp.StatusCode != http.StatusFound {
+	if resp.StatusCode != http.StatusOK {
 		t.Errorf(
 			"expected status code: %d but got: %d",
 			http.StatusCreated,
@@ -263,21 +252,8 @@ func TestDataStorage_RetrieveData(t *testing.T) {
 	t.Run("nonexistent name", func(t *testing.T) {
 
 		// Make GET request
-		path := fmt.Sprintf("%s?name=%s", testURL, testName+"foo")
-		req, err := http.NewRequest(http.MethodGet, path, nil)
-		if err != nil {
-			t.Fatalf(
-				"unexpected error occurred: %v",
-				err,
-			)
-		}
-		resp, err = testClient.RoundTrip(req)
-		if err != nil {
-			t.Fatalf(
-				"unexpected error occurred: %v",
-				err,
-			)
-		}
+		params["name"] = testName + "foo"
+		resp, err := requests.GetRequest(testURL, &params, testClient)
 
 		// Check status code
 		if resp.StatusCode != http.StatusNotFound {

--- a/pkg/handlers/datastorage_test.go
+++ b/pkg/handlers/datastorage_test.go
@@ -209,6 +209,12 @@ func TestDataStorage_RetrieveData(t *testing.T) {
 	params := make(map[string]string)
 	params["name"] = testName
 	resp, err := requests.GetRequest(testURL, &params, testClient)
+	if err != nil {
+		t.Fatalf(
+			"unexpected error occurred: %v",
+			err,
+		)
+	}
 
 	// Check status code
 	if resp.StatusCode != http.StatusOK {
@@ -254,6 +260,12 @@ func TestDataStorage_RetrieveData(t *testing.T) {
 		// Make GET request
 		params["name"] = testName + "foo"
 		resp, err := requests.GetRequest(testURL, &params, testClient)
+		if err != nil {
+			t.Fatalf(
+				"unexpected error occurred: %v",
+				err,
+			)
+		}
 
 		// Check status code
 		if resp.StatusCode != http.StatusNotFound {

--- a/pkg/handlers/datastorage_test.go
+++ b/pkg/handlers/datastorage_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -271,7 +270,6 @@ func TestDataStorage_DeleteData(t *testing.T) {
 	)
 	testServer := httptest.NewServer(dsh.HandleClientRequest())
 	testURL := testServer.URL + "/datastorage"
-	testClient := http.DefaultTransport
 
 	testName := "testname"
 	testData := []byte("test data")
@@ -284,16 +282,8 @@ func TestDataStorage_DeleteData(t *testing.T) {
 	}
 
 	// Make GET request
-	path := fmt.Sprintf("%s?name=%s", testURL, testName)
-	req, err := http.NewRequest(http.MethodDelete, path, nil)
-	if err != nil {
-		t.Fatalf(
-			"unexpected error occurred: %v",
-			err,
-		)
-	}
-	// resp, err := testClient.Get(path)
-	resp, err := testClient.RoundTrip(req)
+	params := map[string]string{"name": testName}
+	resp, err := requests.CustomRequest(testURL, http.MethodDelete, &params, nil)
 	if err != nil {
 		t.Fatalf(
 			"unexpected error occurred: %v",
@@ -342,15 +332,7 @@ func TestDataStorage_DeleteData(t *testing.T) {
 	t.Run("nonexistent name", func(t *testing.T) {
 
 		// Make GET request
-		path := fmt.Sprintf("%s?name=%s", testURL, testName)
-		req, err := http.NewRequest(http.MethodDelete, path, nil)
-		if err != nil {
-			t.Fatalf(
-				"unexpected error occurred: %v",
-				err,
-			)
-		}
-		resp, err = testClient.RoundTrip(req)
+		resp, err := requests.CustomRequest(testURL, http.MethodDelete, &params, nil)
 		if err != nil {
 			t.Fatalf(
 				"unexpected error occurred: %v",

--- a/pkg/handlers/datastorage_test.go
+++ b/pkg/handlers/datastorage_test.go
@@ -281,7 +281,7 @@ func TestDataStorage_DeleteData(t *testing.T) {
 		)
 	}
 
-	// Make GET request
+	// Make DELETE request
 	params := map[string]string{"name": testName}
 	resp, err := requests.CustomRequest(testURL, http.MethodDelete, &params, nil)
 	if err != nil {
@@ -331,7 +331,7 @@ func TestDataStorage_DeleteData(t *testing.T) {
 
 	t.Run("nonexistent name", func(t *testing.T) {
 
-		// Make GET request
+		// Make DELETE request
 		resp, err := requests.CustomRequest(testURL, http.MethodDelete, &params, nil)
 		if err != nil {
 			t.Fatalf(

--- a/pkg/utils/requests.go
+++ b/pkg/utils/requests.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// GetRequest executes a GET request to the desired `url`, adding any `params`
+// to the raw query.
+//
+// It optionally can use a given http.Client, or will default to a standard
+// client with a 10s timeout.
+//
+// Returns the parsed response or error if this function failed.
+func GetRequest(url string, params *map[string]string, client *http.Client) (map[string]any, error) {
+	if client == nil {
+		client = &http.Client{
+			Timeout: 10 * time.Second,
+		}
+	}
+
+	// Construct request
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add query params
+	if params != nil {
+		query := req.URL.Query()
+		for k, v := range *params {
+			query.Add(k, v)
+		}
+		req.URL.RawQuery = query.Encode()
+	}
+
+	// Execute the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read response
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var parsed map[string]any
+	json.Unmarshal([]byte(body), &parsed)
+
+	return parsed, nil
+}

--- a/pkg/utils/requests.go
+++ b/pkg/utils/requests.go
@@ -33,23 +33,22 @@ func GetRequest(
 		}
 	}
 
-	// Construct request
-	req, err := http.NewRequest(http.MethodGet, address, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Add query params
-	if params != nil {
-		query := req.URL.Query()
+	// Add query params if applicable
+	var queryParams *url.Values
+	if params != nil && len(*params) != 0 {
 		for k, v := range *params {
-			query.Add(k, v)
+			queryParams.Add(k, v)
 		}
-		req.URL.RawQuery = query.Encode()
 	}
 
 	// Execute the request
-	resp, err := client.Do(req)
+	resp, err := client.Get(address + func() string {
+		if queryParams != nil {
+			return (*queryParams).Encode()
+		} else {
+			return ""
+		}
+	}())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/requests.go
+++ b/pkg/utils/requests.go
@@ -1,9 +1,16 @@
 package utils
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -14,7 +21,12 @@ import (
 // client with a 10s timeout.
 //
 // Returns the parsed response or error if this function failed.
-func GetRequest(url string, params *map[string]string, client *http.Client) (map[string]any, error) {
+func GetRequest(
+	address string,
+	params *map[string]string,
+	client *http.Client,
+) (map[string]any, error) {
+	// Init client if none given
 	if client == nil {
 		client = &http.Client{
 			Timeout: 10 * time.Second,
@@ -22,7 +34,7 @@ func GetRequest(url string, params *map[string]string, client *http.Client) (map
 	}
 
 	// Construct request
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, address, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -43,12 +55,120 @@ func GetRequest(url string, params *map[string]string, client *http.Client) (map
 	}
 
 	// Read response
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 	var parsed map[string]any
-	json.Unmarshal([]byte(body), &parsed)
+	err = json.Unmarshal([]byte(body), &parsed)
 
-	return parsed, nil
+	return parsed, err
+}
+
+func PostRequest(
+	address string,
+	contentType string,
+	params *map[string]string,
+	files *map[string][]byte, // TODO: accomadate direct file names
+	client *http.Client,
+) (map[string]any, error) {
+	// Init client if none given
+	if client == nil {
+		client = &http.Client{
+			Timeout: 10 * time.Second,
+		}
+	}
+
+	// Construct request
+	var (
+		req *http.Request
+		err error
+	)
+	switch contentType {
+	case "application/x-www-form-urlencoded":
+		data := url.Values{}
+		if params != nil {
+			for k, v := range *params {
+				data.Set(k, v)
+			}
+		}
+		req, err = http.NewRequest(http.MethodPost, address, strings.NewReader(data.Encode()))
+		req.Header.Set("Content-type", contentType)
+		req.Header.Add("Content-length", strconv.Itoa(len(data.Encode())))
+		if err != nil {
+			return nil, err
+		}
+
+	case "multipart/form-data":
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+
+		// Write additional params
+		if params != nil {
+			for k, v := range *params {
+				fw, err := writer.CreateFormField(k)
+				if err != nil {
+					return nil, err
+				}
+				_, err = io.Copy(fw, strings.NewReader(v))
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		// Write files
+		if files != nil {
+			for k, f := range *files {
+				fw, err := writer.CreateFormFile(k, k)
+				if err != nil {
+					return nil, err
+				}
+				_, err = io.Copy(fw, bytes.NewReader(f))
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		// Create the request
+		writer.Close()
+		req, err = http.NewRequest(http.MethodPost, address, bytes.NewReader(body.Bytes()))
+		req.Header.Set("Content-type", writer.FormDataContentType())
+
+	case "application/json":
+		// Marshal the params
+		if params == nil || len(*params) == 0 {
+			return nil, errors.New("no parameters provided")
+		}
+		jsonParams, err := json.Marshal(*params)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create request
+		req, err = http.NewRequest(http.MethodPost, address, bytes.NewBuffer(jsonParams))
+		req.Header.Set("Content-type", contentType)
+
+	default:
+		return nil, errors.New("unsupported content type")
+	}
+
+	// Execute the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read response
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var parsed map[string]any
+	err = json.Unmarshal([]byte(body), &parsed)
+
+	return parsed, err
 }

--- a/pkg/utils/requests/requests.go
+++ b/pkg/utils/requests/requests.go
@@ -1,4 +1,4 @@
-package utils
+package requests
 
 import (
 	"bytes"

--- a/pkg/utils/requests/requests.go
+++ b/pkg/utils/requests/requests.go
@@ -56,9 +56,13 @@ func GetRequest(
 
 // PostRequest executes a POST request to the desired `targetURL`, supporting
 // 3 `contentType`:
-// application/x-www-form-urlencoded
-// multipart/form-data
-// application/json
+//
+// - application/x-www-form-urlencoded
+//
+// - multipart/form-data
+//
+// - application/json
+//
 //
 // Pass any form parameters as `params`, and file/data to POST as `uploadData`.
 //

--- a/pkg/utils/requests/requests.go
+++ b/pkg/utils/requests/requests.go
@@ -75,7 +75,7 @@ func PostRequest(
 	switch contentType {
 	case "application/x-www-form-urlencoded":
 		data := url.Values{}
-		if params != nil {
+		if params != nil && len(*params) > 0 {
 			for k, v := range *params {
 				data.Set(k, v)
 			}

--- a/pkg/utils/requests/requests.go
+++ b/pkg/utils/requests/requests.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -25,7 +24,7 @@ func GetRequest(
 	targetURL string,
 	params *map[string]string,
 	client *http.Client,
-) (map[string]any, error) {
+) (*http.Response, error) {
 	// Init client if none given
 	if client == nil {
 		client = &http.Client{
@@ -36,6 +35,7 @@ func GetRequest(
 	// Add query params if applicable
 	var queryParams *url.Values
 	if params != nil && len(*params) != 0 {
+		queryParams = &url.Values{}
 		for k, v := range *params {
 			queryParams.Add(k, v)
 		}
@@ -44,25 +44,13 @@ func GetRequest(
 	// Execute the request
 	resp, err := client.Get(targetURL + func() string {
 		if queryParams != nil {
-			return (*queryParams).Encode()
+			return "?" + (*queryParams).Encode()
 		} else {
 			return ""
 		}
 	}())
-	if err != nil {
-		return nil, err
-	}
 
-	// Read response
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	var parsed map[string]any
-	err = json.Unmarshal([]byte(body), &parsed)
-
-	return parsed, err
+	return resp, err
 }
 
 func PostRequest(
@@ -71,7 +59,7 @@ func PostRequest(
 	params *map[string]string,
 	uploadData *map[string][]byte, // TODO: accomadate direct file names
 	client *http.Client,
-) (map[string]any, error) {
+) (*http.Response, error) {
 	// Init client if none given
 	if client == nil {
 		client = &http.Client{
@@ -160,14 +148,5 @@ func PostRequest(
 		return nil, err
 	}
 
-	// Read response
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	var parsed map[string]any
-	err = json.Unmarshal([]byte(body), &parsed)
-
-	return parsed, err
+	return resp, err
 }

--- a/pkg/utils/requests/requests.go
+++ b/pkg/utils/requests/requests.go
@@ -122,6 +122,9 @@ func PostRequest(
 		// Create the request
 		writer.Close()
 		req, err = http.NewRequest(http.MethodPost, targetURL, bytes.NewReader(body.Bytes()))
+		if err != nil {
+			return nil, err
+		}
 		req.Header.Set("Content-type", writer.FormDataContentType())
 
 	case "application/json":
@@ -136,6 +139,9 @@ func PostRequest(
 
 		// Create request
 		req, err = http.NewRequest(http.MethodPost, targetURL, bytes.NewBuffer(jsonParams))
+		if err != nil {
+			return nil, err
+		}
 		req.Header.Set("Content-type", contentType)
 
 	default:

--- a/pkg/utils/requests/requests.go
+++ b/pkg/utils/requests/requests.go
@@ -13,13 +13,14 @@ import (
 	"time"
 )
 
-// GetRequest executes a GET request to the desired `url`, adding any `params`
-// to the raw query.
+// GetRequest executes a GET request to the desired `targetURL`, adding any
+// `params` to the raw query.
 //
 // It optionally can use a given http.Client, or will default to a standard
 // client with a 10s timeout.
 //
-// Returns the parsed response or error if this function failed.
+// Returns the raw response or error if this function failed.
+// TODO: support authentication methods
 func GetRequest(
 	targetURL string,
 	params *map[string]string,
@@ -53,6 +54,19 @@ func GetRequest(
 	return resp, err
 }
 
+// PostRequest executes a POST request to the desired `targetURL`, supporting
+// 3 `contentType`:
+// application/x-www-form-urlencoded
+// multipart/form-data
+// application/json
+//
+// Pass any form parameters as `params`, and file/data to POST as `uploadData`.
+//
+// It optionally can use a given http.Client, or will default to a standard
+// client with a 10s timeout.
+//
+// Returns the raw response or error if this function failed.
+// TODO: support authentication methods
 func PostRequest(
 	targetURL string,
 	contentType string,


### PR DESCRIPTION
<!--Note these comments do not need to be deleted, and will not show up in the final PR-->

# Summary

### Related Issues
<!--Required-->

- Completes #10

### Contributors
<!--Required-->
- @dvo-dev: implementer

### Affected Modules
<!--Required-->

- `pkg/utils/requests` (new)
- `pkg/handlers`

### Description
<!--Required-->
Adds basic http request util wrappers:

- `pkg.utils.requests.GetRequest`
- `pkg.utils.requests.PostRequest`
- `pkg.utils.requests.CustomRequest` (any request method not `GET` or `POST`)

Inside a new package `utils`, which in the future can be used to house other easily reusable code.

`GetRequest` and `CustomRequest` are relatively self explanator, with the caveat that `CustomRequest` should only be used for basic requests - it simply executes the request method on the provided URL, directly baking any passed parameters into the raw URL.

`PostRequest` at this time supports `contentType`:

- `application/x-www-form-urlencoded`
- `multipart/form-data`
- `application/json`

All 3 can take optional form parameters passed as a `*map[string]string`, while `multipart/form-data` can also `POST` data directly to a server from the input `uploadData`, which maps the form param key to a slice of bytes (the data).

# Testing (Unit/Integration/Performance)
<!--Optional if no tests altered/added-->
No tests for the util directly (@alexander-ma will implement this as a learning experience), replaces `pkg/handlers/datastorage` test requests with the util's.

# Points of Attention
<!--Optional, use as often as possible-->
- There should be support to set authentication in these wrappers in the future
- Set default client values as a constant somewhere
